### PR TITLE
Update dependabot.yml configurations.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,7 @@
 version: 2
 updates:
 - package-ecosystem: nuget
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: npm
-  directory: "/"
+  directory: "/api"
   schedule:
     interval: daily
   open-pull-requests-limit: 10


### PR DESCRIPTION
Remove the npm package ecosystem
Change directory path to "/api" for NuGet package ecosystem