### PR TITLE
PR Fix to avoid double encryption. It fixes back channel logout. But it …

### DIFF
--- a/api/CcsSso.Security.Api/Controllers/SecurityController.cs
+++ b/api/CcsSso.Security.Api/Controllers/SecurityController.cs
@@ -602,7 +602,9 @@ namespace CcsSso.Security.Api.Controllers
         else
         {
           var sidCache = await _securityCacheService.GetValueAsync<string>(state);
-          sid = _cryptographyService.EncryptString(sidCache, _applicationConfigurationInfo.CryptoSettings.CookieEncryptionKey);
+          // TODO - This doubel encryption break back channel logout feature. It will be revieved later.
+          // sid = _cryptographyService.EncryptString(sidCache, _applicationConfigurationInfo.CryptoSettings.CookieEncryptionKey);
+          sid = sidCache;
         }
         //Re-assign the same session id with new expiration time
         Response.Cookies.Delete(sessionCookieName);


### PR DESCRIPTION
Fix to avoid double encryption. It fixes back channel logout. But it …
…covers case when there was no previous logged in session available in the browser.