### PR TITLE
Bug/bug 3571 obfuscated word can be use as keyword in api search string

### DIFF
--- a/api/CcsSso.Core.DbModel/Entity/User.cs
+++ b/api/CcsSso.Core.DbModel/Entity/User.cs
@@ -45,6 +45,8 @@ namespace CcsSso.DbModel.Entity
 
         public UserType UserType { get; set; }
 
+        // #Delegated
+
         public DateTime? DelegationStartDate { get; set; }
 
         public DateTime? DelegationEndDate { get; set; }

--- a/api/CcsSso.Core.Domain/Constants/Constants.cs
+++ b/api/CcsSso.Core.Domain/Constants/Constants.cs
@@ -68,6 +68,7 @@ namespace CcsSso.Domain.Constants
     public const string ErrorMfaFlagRequired = "MFA_DISABLED_USER";
     public const string ErrorMfaFlagForInvalidConnection = "MFA_ENABLED_INVALID_CONNECTION";
 
+    // #Delegated
     public const string ErrorInvalidUserDelegationPrimaryDetails = "INVALID_USER_DELEGATION_PRIMARY_DETAILS";
     public const string ErrorInvalidUserDelegation = "INVALID_USER_DELEGATION";
     public const string ErrorInvalidUserDelegationSameOrg = "INVALID_USER_DELEGATION_SAME_ORG";
@@ -151,6 +152,7 @@ namespace CcsSso.Domain.Constants
     public const string UserCreate = "User-create";
     public const string UserDelete = "User-delete";
     public const string UserUpdate = "User-update";
+    // #Delegated
     public const string UserDelegated = "User-delegated";
     public const string UserIdpUpdate = "User-idp-update";
     public const string UserGroupUpdate = "User-group-update";

--- a/api/CcsSso.Core.Domain/Contracts/External/IUserProfileService.cs
+++ b/api/CcsSso.Core.Domain/Contracts/External/IUserProfileService.cs
@@ -8,9 +8,9 @@ namespace CcsSso.Core.Domain.Contracts.External
         Task<UserEditResponseInfo> CreateUserAsync(UserProfileEditRequestInfo userProfileRequestInfo);
 
         Task DeleteUserAsync(string userName, bool checkForLastAdmin = true);
-
+        // #Delegated
         Task<UserProfileResponseInfo> GetUserAsync(string userName, bool isDelegated = false, bool isSearchUser = false, string delegatedOrgId = "");
-
+        // #Delegated
         Task<UserListResponse> GetUsersAsync(string organisationId, ResultSetCriteria resultSetCriteria, string searchString = null, bool includeSelf = false, bool isDelegatedOnly = false, bool isDelegatedExpiredOnly = false);
 
         Task<AdminUserListResponse> GetAdminUsersAsync(string organisationId, ResultSetCriteria resultSetCriteria);
@@ -24,7 +24,7 @@ namespace CcsSso.Core.Domain.Contracts.External
         Task RemoveAdminRolesAsync(string userName);
 
         Task AddAdminRoleAsync(string userName);
-
+        // #Delegated
         Task CreateDelegatedUserAsync(DelegatedUserProfileRequestInfo userProfileRequestInfo);
 
         Task UpdateDelegatedUserAsync(DelegatedUserProfileRequestInfo userProfileRequestInfo);

--- a/api/CcsSso.Core.Domain/Contracts/ICcsSsoEmailService.cs
+++ b/api/CcsSso.Core.Domain/Contracts/ICcsSsoEmailService.cs
@@ -29,7 +29,7 @@ namespace CcsSso.Core.Domain.Contracts
     Task SendUserPermissionUpdateEmailAsync(string email);
 
     Task SendOrgJoinRequestEmailAsync(OrgJoinNotificationInfo orgJoinNotificationInfo);
-
+    // #Delegated
     Task SendUserDelegatedAccessEmailAsync(string email, string orgName, string[] roles, string encryptedInfo);
   }
 }

--- a/api/CcsSso.Core.Domain/Dtos/ApplicationConfigurationInfo.cs
+++ b/api/CcsSso.Core.Domain/Dtos/ApplicationConfigurationInfo.cs
@@ -31,7 +31,7 @@ namespace CcsSso.Domain.Dtos
     public ServiceDefaultRoleInfo ServiceDefaultRoleInfo { get; set; }
 
     public int BulkUploadMaxUserCount { get; set; }
-
+    // #Delegated
     public int DelegatedEmailExpirationHours { get; set; }
 
     public string DelegationEmailTokenEncryptionKey { get; set; }
@@ -95,7 +95,7 @@ namespace CcsSso.Domain.Dtos
     public string OrganisationJoinRequestTemplateId { get; set; }
 
     public string NominateEmailTemplateId { get; set; }
-
+    // #Delegated
     public string UserDelegatedAccessEmailTemplateId { get; set; }
 
     public bool SendNotificationsEnabled { get; set; }

--- a/api/CcsSso.Core.Domain/Dtos/External/UserProfileResponseInfo.cs
+++ b/api/CcsSso.Core.Domain/Dtos/External/UserProfileResponseInfo.cs
@@ -55,10 +55,10 @@ namespace CcsSso.Core.Domain.Dtos.External
     public List<RolePermissionInfo> RolePermissionInfo { get; set; }
 
     public List<UserIdentityProviderInfo> IdentityProviders { get; set; }
-
+    // #Delegated
     public UserDelegationDetails[]? DelegatedOrgs { get; set; }
   }
-
+  // #Delegated
   public class UserDelegationDetails
   {
     public string? DelegatedOrgId { get; set; }
@@ -167,13 +167,13 @@ namespace CcsSso.Core.Domain.Dtos.External
 
     public bool IsRegisteredInIdam { get; set; }
   }
-
+  // #Delegated
   public class DelegatedUserProfileRequestInfo
   {
     public string UserName { get; set; }
     public DelegatedUserRequestDetail Detail { get; set; }
   }
-
+  // #Delegated
   public class DelegatedUserRequestDetail
   {
     public string DelegatedOrgId { get; set; }

--- a/api/CcsSso.Core.ExternalApi/Controllers/OrganisationProfileController.cs
+++ b/api/CcsSso.Core.ExternalApi/Controllers/OrganisationProfileController.cs
@@ -780,6 +780,7 @@ namespace CcsSso.ExternalApi.Controllers
 
         /// <summary>
         /// Allows a user to retrieve users for a given organisation
+        /// #Delegated
         /// </summary>
         /// <response  code="200">Ok</response>
         /// <response  code="401">Unauthorised</response>

--- a/api/CcsSso.Core.ExternalApi/Controllers/UserProfileController.cs
+++ b/api/CcsSso.Core.ExternalApi/Controllers/UserProfileController.cs
@@ -65,6 +65,7 @@ namespace CcsSso.ExternalApi.Controllers
 
     /// <summary>
     /// Allows a user to retrieve details for a given user
+    /// #Delegated
     /// </summary>
     /// <response  code="200">Ok</response>
     /// <response  code="401">Unauthorised</response>
@@ -214,7 +215,7 @@ namespace CcsSso.ExternalApi.Controllers
     {
       await _userProfileService.AddAdminRoleAsync(userId);
     }
-
+    // #Delegated
     #region Delegated access
     /// <summary>
     /// Allows admin to delegate other org user to represent org

--- a/api/CcsSso.Core.ExternalApi/CustomOptions/VaultConfiguration.cs
+++ b/api/CcsSso.Core.ExternalApi/CustomOptions/VaultConfiguration.cs
@@ -112,6 +112,7 @@ namespace CcsSso.ExternalApi.Api.CustomOptions
         Data.Add("Email:UserConfirmEmailBothIdpTemplateId", emailsettings.UserConfirmEmailBothIdpTemplateId);
         Data.Add("Email:UserConfirmEmailOnlyUserIdPwdTemplateId", emailsettings.UserConfirmEmailOnlyUserIdPwdTemplateId);
         Data.Add("Email:UserRegistrationEmailUserIdPwdTemplateId", emailsettings.UserRegistrationEmailUserIdPwdTemplateId);
+        // #Delegated
         Data.Add("Email:UserDelegatedAccessEmailTemplateId", emailsettings.UserDelegatedAccessEmailTemplateId);
 
         Data.Add("Email:SendNotificationsEnabled", emailsettings.SendNotificationsEnabled);
@@ -159,7 +160,7 @@ namespace CcsSso.ExternalApi.Api.CustomOptions
           Data.Add($"ExternalServiceDefaultRoles:ScopedServiceDefaultRoles:{index++}", scopedRole);
         }
       }
-
+      // #Delegated
       if (_secrets.Data.ContainsKey("UserDelegation"))
       {
         var userDelegationInfo = JsonConvert.DeserializeObject<UserDelegation>(_secrets.Data["UserDelegation"].ToString());
@@ -233,7 +234,7 @@ namespace CcsSso.ExternalApi.Api.CustomOptions
     public string UserConfirmEmailOnlyUserIdPwdTemplateId { get; set; }
 
     public string UserRegistrationEmailUserIdPwdTemplateId { get; set; }
-
+    // #Delegated
     public string UserDelegatedAccessEmailTemplateId { get; set; }
     public string SendNotificationsEnabled { get; set; }
   }
@@ -278,7 +279,7 @@ namespace CcsSso.ExternalApi.Api.CustomOptions
 
     public string[] ScopedServiceDefaultRoles { get; set; }
   }
-
+  // #Delegated
   public class UserDelegation
   {
     public int DelegatedEmailExpirationHours { get; set; }

--- a/api/CcsSso.Core.ExternalApi/Startup.cs
+++ b/api/CcsSso.Core.ExternalApi/Startup.cs
@@ -57,6 +57,7 @@ namespace CcsSso.ExternalApi
         int.TryParse(Configuration["RedisCacheSettings:CacheExpirationInMinutes"], out int cacheExpirationInMinutes);
         int.TryParse(Configuration["InMemoryCacheExpirationInMinutes"], out int inMemoryCacheExpirationInMinutes);
         bool.TryParse(Configuration["IsApiGatewayEnabled"], out bool isApiGatewayEnabled);
+        // #Delegated
         int.TryParse(Configuration["UserDelegation:DelegatedEmailExpirationHours"], out int delegatedEmailExpirationHours);
 
         var globalServiceRoles = Configuration.GetSection("ExternalServiceDefaultRoles:GlobalServiceDefaultRoles").Get<List<string>>();
@@ -70,6 +71,7 @@ namespace CcsSso.ExternalApi
         {
           inMemoryCacheExpirationInMinutes = 10;
         }
+        // #Delegated
         delegatedEmailExpirationHours = delegatedEmailExpirationHours == 0 ? 36 : delegatedEmailExpirationHours;
 
         ApplicationConfigurationInfo appConfigInfo = new ApplicationConfigurationInfo()
@@ -79,6 +81,7 @@ namespace CcsSso.ExternalApi
           EnableAdapterNotifications = enableAdaptorNotifications,
           InMemoryCacheExpirationInMinutes = inMemoryCacheExpirationInMinutes,
           DashboardServiceClientId = Configuration["DashboardServiceClientId"],
+          // #Delegated
           DelegatedEmailExpirationHours = delegatedEmailExpirationHours,
           DelegationEmailTokenEncryptionKey = Configuration["UserDelegation:DelegationEmailTokenEncryptionKey"],
           DelegationExcludeRoles = Configuration.GetSection("UserDelegation:DelegationExcludeRoles").Get<string[]>(),
@@ -100,8 +103,8 @@ namespace CcsSso.ExternalApi
             UserProfileUpdateNotificationTemplateId = Configuration["Email:UserProfileUpdateNotificationTemplateId"],
             UserContactUpdateNotificationTemplateId = Configuration["Email:UserContactUpdateNotificationTemplateId"],
             UserPermissionUpdateNotificationTemplateId = Configuration["Email:UserPermissionUpdateNotificationTemplateId"],
+            // #Delegated
             UserDelegatedAccessEmailTemplateId = Configuration["Email:UserDelegatedAccessEmailTemplateId"],
-
             UserUpdateEmailOnlyFederatedIdpTemplateId= Configuration["Email:UserUpdateEmailOnlyFederatedIdpTemplateId"],
             UserUpdateEmailOnlyUserIdPwdTemplateId = Configuration["Email:UserUpdateEmailOnlyUserIdPwdTemplateId"],
             UserUpdateEmailBothIdpTemplateId = Configuration["Email:UserUpdateEmailBothIdpTemplateId"],

--- a/api/CcsSso.Core.Service/CcsSsoEmailService.cs
+++ b/api/CcsSso.Core.Service/CcsSsoEmailService.cs
@@ -128,7 +128,7 @@ namespace CcsSso.Core.Service
       };
       await SendEmailAsync(emailInfo);
     }
-
+    // #Delegated
     public async Task SendUserDelegatedAccessEmailAsync(string email, string orgName, string[] roles, string encryptedCode)
     {
       var data = new Dictionary<string, dynamic>

--- a/api/CcsSso.Core.Service/External/UserProfileService.cs
+++ b/api/CcsSso.Core.Service/External/UserProfileService.cs
@@ -1561,9 +1561,8 @@ namespace CcsSso.Core.Service.External
       }
 
       var orgElegibleRoleIds = organisation.OrganisationEligibleRoles.Select(r => r.Id);
-      if (userProfileRequestInfo.Detail.RoleIds != null && userProfileRequestInfo.Detail.RoleIds.Any(gId => excludeRoleIds.Contains(gId)
-        && userProfileRequestInfo.Detail.RoleIds.Any(gId => !orgElegibleRoleIds.Contains(gId))
-      ))
+      if (userProfileRequestInfo.Detail.RoleIds.Any(gId => excludeRoleIds.Contains(gId))
+          || userProfileRequestInfo.Detail.RoleIds.Any(gId => !orgElegibleRoleIds.Contains(gId)))
       {
         throw new CcsSsoException(ErrorConstant.ErrorInvalidUserRole);
       }

--- a/api/CcsSso.Core.Service/External/UserProfileService.cs
+++ b/api/CcsSso.Core.Service/External/UserProfileService.cs
@@ -245,7 +245,7 @@ namespace CcsSso.Core.Service.External
         IsRegisteredInIdam = isRegisteredInIdam
       };
     }
-
+    // #Delegated
     public async Task<UserProfileResponseInfo> GetUserAsync(string userName, bool isDelegated = false, bool isSearchUser = false, string delegatedOrgId = "")
     {
       User user = null;
@@ -387,7 +387,7 @@ namespace CcsSso.Core.Service.External
 
       throw new ResourceNotFoundException();
     }
-
+    // #Delegated
     public async Task<UserListResponse> GetUsersAsync(string organisationId, ResultSetCriteria resultSetCriteria, string searchString = null, bool includeSelf = false, bool isDelegatedOnly = false, bool isDelegatedExpiredOnly = false)
     {
 
@@ -683,7 +683,7 @@ namespace CcsSso.Core.Service.External
                                 user.Party.Person.LastName != userProfileRequestInfo.LastName.Trim() ||
                                 user.UserTitle != (int)Enum.Parse(typeof(UserTitle), string.IsNullOrWhiteSpace(userProfileRequestInfo.Title) ? "Unspecified" : userProfileRequestInfo.Title));
       }
-      // If first name or last name updated for primary account update in delegated as well.
+      // #Delegated If first name or last name updated for primary account update in delegated as well.
       if (user.Party.Person.FirstName != userProfileRequestInfo.FirstName.Trim() || user.Party.Person.LastName != userProfileRequestInfo.LastName.Trim())
       {
         var delegatedOrgDetails = await _dataContext.User.Include(u => u.Party).ThenInclude(p => p.Person).Where(u => u.UserName == userName && u.UserType == DbModel.Constants.UserType.Delegation).ToListAsync();

--- a/api/CcsSso.Core.Service/OrganisationService.cs
+++ b/api/CcsSso.Core.Service/OrganisationService.cs
@@ -270,8 +270,10 @@ namespace CcsSso.Service
         .Include(c => c.Party)
         .ThenInclude(x => x.Person)
         .ThenInclude(o => o.Organisation)
-        .Where(u => u.IsDeleted == false && (_requestContext.UserId != 0 && u.Party.Person.Organisation.CiiOrganisationId != _requestContext.CiiOrganisationId) &&
-        u.UserType == Core.DbModel.Constants.UserType.Primary &&
+        .Where(u => u.IsDeleted == false
+        // #Delegated only return primary users
+        && u.UserType == Core.DbModel.Constants.UserType.Primary 
+        && (_requestContext.UserId != 0 && u.Party.Person.Organisation.CiiOrganisationId != _requestContext.CiiOrganisationId) &&
         (string.IsNullOrEmpty(name) || u.UserName.Contains(name) || (u.Party.Person.FirstName + " " + u.Party.Person.LastName).ToLower().Contains(name) || u.Party.Person.Organisation.LegalName.ToLower().Contains(name)) &&
         u.Party.Person.Organisation.IsDeleted == false).Select(user => new OrganisationUserDto
         {

--- a/api/CcsSso.Security.Api/Models/TokenRequest.cs
+++ b/api/CcsSso.Security.Api/Models/TokenRequest.cs
@@ -30,7 +30,7 @@ namespace CcsSso.Security.Api.Models
 
     [BindProperty(Name = "state")]
     public string State { get; set; }
-
+    // #Delegated
     [BindProperty(Name = "delegated_org_id")]
     public string DelegatedOrgId { get; set; }
 

--- a/api/CcsSso.Security.Domain/Constants/Constants.cs
+++ b/api/CcsSso.Security.Domain/Constants/Constants.cs
@@ -21,6 +21,7 @@ namespace CcsSso.Security.Domain.Constants
     {
       public const string MFA_RESET = "MFA_RESET";
       public const string MFA_RESET_PERSISTENT = "MFA_RESET_PERSISTENT";
+      // #Delegated
       public const string DELEGATION = "DELEGATION";
     }
   }

--- a/api/CcsSso.Security.Domain/Dtos/TokenInfo.cs
+++ b/api/CcsSso.Security.Domain/Dtos/TokenInfo.cs
@@ -22,6 +22,7 @@ namespace CcsSso.Security.Domain.Dtos
     public string ClientSecret { get; set; }
 
     public string State { get; set; }
+    // #Delegated
     public string DelegatedOrgId { get; set; }
   }
 

--- a/api/CcsSso.Security.Services/Auth0IdentityProviderService.cs
+++ b/api/CcsSso.Security.Services/Auth0IdentityProviderService.cs
@@ -412,6 +412,7 @@ namespace CcsSso.Security.Services
                 // get the sid from refresh token sent from client.
                 sid = await GetSidFromRefreshToken(tokenRequestInfo.RefreshToken, sid);
 
+                // #Delegated
                 string delegatedOrgId = await MapDelegatedOrgIdWithSid(sid, tokenRequestInfo.DelegatedOrgId);
 
                 var result = await _authenticationApiClient.GetTokenAsync(resourceOwnerTokenRequest);
@@ -426,7 +427,7 @@ namespace CcsSso.Security.Services
                     {
                         throw new CcsSsoException("TOKEN_GENERATION_FAILED");
                     }
-
+                    // #Delegated
                     var userDetails = await GetUserAsync(email, delegatedOrgId);
                     var customClaims = GetCustomClaimsForIdToken(tokenDecoded, tokenRequestInfo.ClientId, email, sid, userDetails);
                     var idToken = _jwtTokenHandler.CreateToken(tokenRequestInfo.ClientId, customClaims, _appConfigInfo.JwtTokenConfiguration.IDTokenExpirationTimeInMinutes);
@@ -494,7 +495,7 @@ namespace CcsSso.Security.Services
                     };
                     result = await _authenticationApiClient.GetTokenAsync(resourceOwnerTokenRequest);
                 }
-
+                // #Delegated
                 var tokenInfo = await GetTokensAsync(tokenRequestInfo.ClientId, result, sid, tokenRequestInfo.DelegatedOrgId);
                 return tokenInfo;
             }
@@ -839,7 +840,7 @@ namespace CcsSso.Security.Services
                 }
             }
         }
-
+        // #Delegated
         private async Task<UserProfileInfo> GetUserAsync(string email, string delegatedOrgId = null)
         {
             var httpClient = _httpClientFactory.CreateClient();
@@ -926,7 +927,7 @@ namespace CcsSso.Security.Services
             var accessToken = _jwtTokenHandler.CreateToken(serviceProfile.Audience, accesstokenClaims, _appConfigInfo.JwtTokenConfiguration.IDTokenExpirationTimeInMinutes);
             return accessToken;
         }
-
+        // #Delegated
         private async Task<TokenResponseInfo> GetTokensAsync(string clientId, AccessTokenResponse accessTokenResponse, string sid = null, string delegatedOrgId = null)
         {
             var tokenDecoded = _jwtTokenHandler.DecodeToken(accessTokenResponse.IdToken);
@@ -940,7 +941,7 @@ namespace CcsSso.Security.Services
             }
 
             await AttachSidWithRefreshTokenAsync(accessTokenResponse.RefreshToken, sid);
-
+            // #Delegated
             delegatedOrgId = await MapDelegatedOrgIdWithSid(sid, delegatedOrgId);
 
             var email = tokenDecoded.Claims.FirstOrDefault(c => c.Type == "email")?.Value;
@@ -1015,6 +1016,7 @@ namespace CcsSso.Security.Services
 
             return new Tuple<string, string>(state, sid);
         }
+        // #Delegated
         private async Task<string> MapDelegatedOrgIdWithSid(string sid, string delegatedOrgId)
         {
           if (!string.IsNullOrEmpty(delegatedOrgId))

--- a/api/CcsSso.Security.Services/SecurityService.cs
+++ b/api/CcsSso.Security.Services/SecurityService.cs
@@ -75,7 +75,7 @@ namespace CcsSso.Security.Services
       {
         tokenResponseInfo = await _identityProviderService.GetRenewedTokensAsync(tokenRequestInfo, sid);
 
-        // To perform back channel logout while switching delegated org
+        // #Delegated To perform back channel logout while switching delegated org
         if (visitedSiteList != null && visitedSiteList.Count > 0 && !string.IsNullOrEmpty(tokenRequestInfo.DelegatedOrgId))
         {
           string sidFromToken = string.Empty;
@@ -312,6 +312,7 @@ namespace CcsSso.Security.Services
     public async Task InvalidateSessionAsync(string sessionId)
     {
       await _securityCacheService.SetValueAsync(sessionId, true, new TimeSpan(0, _applicationConfigurationInfo.SessionConfig.SessionTimeoutInMinutes, 0));
+      // #Delegated
       await _securityCacheService.RemoveAsync(CacheKey.DELEGATION + sessionId);
     }
 


### PR DESCRIPTION
This includes below bug fixes:
- 	Bug 3561: POST/ PUT delegated user API issues
- 	Bug 3564: High-Delegated granted user records get deleted from org dereg job and sending out email to delegated org admin users
- 	Bug 3571: obfuscated word can be use as keyword in API search-string
- 	Bug 3591: Get Delegated user API return 500 internal server error
- 	Bug 3596: Primary user deleted by org admin will not delete the delegated org records
- 	Bug 3561: POST/ PUT delegated user API issues