### PR TITLE
User with Manage Service eligibility role cannot access Organisation Identifiers

### DIFF
--- a/api/CcsSso.Core.ExternalApi/Controllers/OrganisationProfileController.cs
+++ b/api/CcsSso.Core.ExternalApi/Controllers/OrganisationProfileController.cs
@@ -91,7 +91,7 @@ namespace CcsSso.ExternalApi.Controllers
         ///     
         /// </remarks>
         [HttpGet("{organisationId}")]
-        [ClaimAuthorise("ORG_ADMINISTRATOR")]
+        [ClaimAuthorise("ORG_ADMINISTRATOR", "MANAGE_SUBSCRIPTIONS")]
         [OrganisationAuthorise("ORGANISATION")]
         [SwaggerOperation(Tags = new[] { "Organisation" })]
         [ProducesResponseType(typeof(OrganisationProfileResponseInfo), 200)]

--- a/api/CcsSso.Core.Service/CiiService.cs
+++ b/api/CcsSso.Core.Service/CiiService.cs
@@ -197,8 +197,22 @@ namespace CcsSso.Service
         if (!string.IsNullOrEmpty(token))
         {
           client.DefaultRequestHeaders.Add("Authorization", token);
+
+          // #1453
+          // Token based authenication is not working in local with CII API, it will wokr on server.
+          // Below condition to exclude this for local machine. 
+          // Send x-api-key only when token is not available
+#if !DEBUG
+          if (client.DefaultRequestHeaders.Any(x => x.Key == "x-api-key"))
+          {
+            client.DefaultRequestHeaders.Remove("x-api-key");
+          }
+#endif
         }
-        url += "/all";
+        else
+        {
+          url += "/all";
+        }
       }
       using var response = await client.GetAsync(url);
       if (response.IsSuccessStatusCode)


### PR DESCRIPTION
[Task 2114](https://dev.azure.com/CCS-Conclave/CCS-Conclave-P2/_workitems/edit/2114): Sprint 14-CON-1453 CCS Admin >Manage Service eligibility >Confirm Organisation page is expected to show all Identifiers- Priority 3- Carry Over

[Task 2116](https://dev.azure.com/CCS-Conclave/CCS-Conclave-P2/_workitems/edit/2116): Sprint 14-CON-1373 User with Manage Service eligibility role cannot access Organisation Identifiers- Same task as Con 1453