### PR TITLE
PR-3473-unauthenticated-endpoint-logout-while-refresh

### DIFF
--- a/api/CcsSso.Core.Api/Middleware/AuthenticationMiddleware.cs
+++ b/api/CcsSso.Core.Api/Middleware/AuthenticationMiddleware.cs
@@ -23,7 +23,7 @@ namespace CcsSso.Core.Api.Middleware
 
     private List<string> allowedPaths = new List<string>()
     {
-      "auth/backchannel-logout,auth/mfa-reset-by-tickets",
+      "auth/backchannel-logout,auth/mfa-reset-by-tickets","auth/refresh-tokens",
       "organisations/registrations", "users/nominees", "users/activation-emails", "cii/schemes", "cii/identifiers",
       "organisations/orgs-by-name","organisations/org-admin-join-notification","configurations/country-details"
     };


### PR DESCRIPTION
refresh token secured endpoint moved back to open end point due to the concern that the browser refresh affect the login status of the session