### PR TITLE
PR-con-3108-Issues_with_some_test_user_accounts_forbidden_error_sprint14

### DIFF
--- a/api/CcsSso.Core.Service/AuthService.cs
+++ b/api/CcsSso.Core.Service/AuthService.cs
@@ -1,3 +1,4 @@
+using CcsSso.Core.DbModel.Constants;
 using CcsSso.Core.Domain.Contracts;
 using CcsSso.Core.Domain.Dtos;
 using CcsSso.Domain.Constants;
@@ -164,8 +165,12 @@ namespace CcsSso.Core.Service
 
         if (string.IsNullOrEmpty(intendedOrganisationId))
         {
-          intendedOrganisationId = await _dataContext.User.Where(u => !u.IsDeleted && u.UserName == _requestContext.RequestIntendedUserName)
-            .Select(u => u.Party.Person.Organisation.CiiOrganisationId).FirstOrDefaultAsync();
+          // Based on the delegation user logic we only come to this point when the request comes for primary user.
+          // primary condition has been added to fix the issue https://crowncommercialservice.atlassian.net/jira/software/c/projects/CON/issues/CON-3108
+
+          intendedOrganisationId = await _dataContext.User
+           .Where(u => !u.IsDeleted && u.UserName == _requestContext.RequestIntendedUserName && (u.UserType == UserType.Primary))
+           .Select(u => u.Party.Person.Organisation.CiiOrganisationId).FirstOrDefaultAsync();
 
           await _remoteCacheService.SetValueAsync<string>($"{CacheKeyConstant.UserOrganisation}-{_requestContext.RequestIntendedUserName}", intendedOrganisationId,
             new TimeSpan(0, _applicationConfigurationInfo.RedisCacheSettings.CacheExpirationInMinutes, 0));


### PR DESCRIPTION
Primary users type filter has been added to verify the organisation id send from the UI to the primary user's organisation.