### PR TITLE
Fixed: Bug 4159: Edge scenario | When org registration api throws ERR…

### DIFF
--- a/api/CcsSso.Core.Domain/Contracts/External/IUserProfileService.cs
+++ b/api/CcsSso.Core.Domain/Contracts/External/IUserProfileService.cs
@@ -26,6 +26,9 @@ namespace CcsSso.Core.Domain.Contracts.External
     Task RemoveAdminRolesAsync(string userName);
 
     Task AddAdminRoleAsync(string userName);
+
+    Task<bool> IsUserExist(string userName);
+
     // #Delegated
     Task CreateDelegatedUserAsync(DelegatedUserProfileRequestInfo userProfileRequestInfo);
 

--- a/api/CcsSso.Core.Service/External/UserProfileService.cs
+++ b/api/CcsSso.Core.Service/External/UserProfileService.cs
@@ -1216,7 +1216,6 @@ namespace CcsSso.Core.Service.External
 
     public async Task<bool> IsUserExist(string userName)
     {
-      _userHelper.ValidateUserName(userName);
       var user = await _dataContext.User.FirstOrDefaultAsync(u => !u.IsDeleted && u.UserName == userName && u.UserType == UserType.Primary);
 
       return user != null;

--- a/api/CcsSso.Core.Service/External/UserProfileService.cs
+++ b/api/CcsSso.Core.Service/External/UserProfileService.cs
@@ -1214,6 +1214,14 @@ namespace CcsSso.Core.Service.External
       }
     }
 
+    public async Task<bool> IsUserExist(string userName)
+    {
+      _userHelper.ValidateUserName(userName);
+      var user = await _dataContext.User.FirstOrDefaultAsync(u => !u.IsDeleted && u.UserName == userName && u.UserType == UserType.Primary);
+
+      return user != null;
+    }
+
     private async Task<bool> IsOrganisationOnlyAdminAsync(User user, string userName)
     {
       int organisationId = user.Party.Person.OrganisationId;
@@ -1303,7 +1311,6 @@ namespace CcsSso.Core.Service.External
         }
       }
     }
-
 
     #region Delegated user
 

--- a/api/CcsSso.Core.Service/OrganisationService.cs
+++ b/api/CcsSso.Core.Service/OrganisationService.cs
@@ -428,6 +428,10 @@ namespace CcsSso.Service
       }
       catch (Exception e)
       {
+        if (await _userProfileService.IsUserExist(organisationRegistrationDto.AdminUserName))
+        {
+          await _userProfileService.DeleteUserAsync(organisationRegistrationDto.AdminUserName, false);
+        }
         await DeleteAsync(ciiOrgId);
         throw;
       }


### PR DESCRIPTION
Edge scenario | When org registration api throws ERROR_ORGANISATION_AUTOVALIDATION error, user is getting created without org
User deleted if created as part of registration and error occurred.