### PR TITLE
Bug 4397: status is 0 when user deleted or expired without click on t…

### DIFF
--- a/api/CcsSso.Core.JobScheduler/ProgramHelpers.cs
+++ b/api/CcsSso.Core.JobScheduler/ProgramHelpers.cs
@@ -60,8 +60,8 @@ namespace CcsSso.Core.JobScheduler
       {
         returnParams = new WrapperApiSettings()
         {
-          ApiKey = _awsParameterStoreService.FindParameterByName(parameters, path + "WrapperApiSettings/Url"),
-          Url = _awsParameterStoreService.FindParameterByName(parameters, path + "WrapperApiSettings/ApiKey"),
+          Url = _awsParameterStoreService.FindParameterByName(parameters, path + "WrapperApiSettings/Url"),
+          ApiKey = _awsParameterStoreService.FindParameterByName(parameters, path + "WrapperApiSettings/ApiKey"),
           ApiGatewayEnabledUserUrl = _awsParameterStoreService.FindParameterByName(parameters, path + "WrapperApiSettings/ApiGatewayEnabledUserUrl"),
           ApiGatewayDisabledUserUrl = _awsParameterStoreService.FindParameterByName(parameters, path + "WrapperApiSettings/ApiGatewayDisabledUserUrl")
         };


### PR DESCRIPTION
[Bug 4397](https://dev.azure.com/CCS-Conclave/CCS-Conclave_P3/_workitems/edit/4397): status is 0 when user deleted or expired without click on the approval link