### PR TITLE
Bug 4401: Sprint 3-On clicking the Approve/Deny in the fleet access verification page after the user was deleted - Navigates to wrong page instead of Fleet access verification page

### DIFF
--- a/api/CcsSso.Core.JobScheduler/ProgramHelpers.cs
+++ b/api/CcsSso.Core.JobScheduler/ProgramHelpers.cs
@@ -60,8 +60,8 @@ namespace CcsSso.Core.JobScheduler
       {
         returnParams = new WrapperApiSettings()
         {
-          ApiKey = _awsParameterStoreService.FindParameterByName(parameters, path + "WrapperApiSettings/Url"),
-          Url = _awsParameterStoreService.FindParameterByName(parameters, path + "WrapperApiSettings/ApiKey"),
+          Url = _awsParameterStoreService.FindParameterByName(parameters, path + "WrapperApiSettings/Url"),
+          ApiKey = _awsParameterStoreService.FindParameterByName(parameters, path + "WrapperApiSettings/ApiKey"),
           ApiGatewayEnabledUserUrl = _awsParameterStoreService.FindParameterByName(parameters, path + "WrapperApiSettings/ApiGatewayEnabledUserUrl"),
           ApiGatewayDisabledUserUrl = _awsParameterStoreService.FindParameterByName(parameters, path + "WrapperApiSettings/ApiGatewayDisabledUserUrl")
         };

--- a/api/CcsSso.Core.Service/External/UserProfileRoleApprovalService.cs
+++ b/api/CcsSso.Core.Service/External/UserProfileRoleApprovalService.cs
@@ -7,7 +7,7 @@ using CcsSso.DbModel.Entity;
 using CcsSso.Domain.Constants;
 using CcsSso.Domain.Contracts;
 using CcsSso.Domain.Dtos;
-using CcsSso.Security.Domain.Exceptions;
+using CcsSso.Domain.Exceptions;
 using CcsSso.Shared.Contracts;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -57,7 +57,7 @@ namespace CcsSso.Core.Service.External
 
       if (pendingRole != null && pendingRole.Count() < pendingRoleIds.Length)
       {
-        throw new CcsSsoException(ErrorConstant.ErrorInvalidDetails);
+        throw new ResourceNotFoundException();
       }
 
       foreach (var pendingRoleId in pendingRoleIds)
@@ -71,7 +71,7 @@ namespace CcsSso.Core.Service.External
 
         if (user == null)
         {
-          throw new RecordNotFoundException();
+          throw new ResourceNotFoundException();
         }
 
         if (status == UserPendingRoleStaus.Rejected)


### PR DESCRIPTION
[Bug 4401](https://dev.azure.com/CCS-Conclave/CCS-Conclave_P3/_workitems/edit/4401): Sprint 3-On clicking the Approve/Deny in the fleet access verification page after the user was deleted - Navigates to wrong page instead of Fleet access verification page