### PR TITLE
4890-Buyer-Both-roles-are-not-assigned-to-Org-admin-one-time-job-runs…

### DIFF
--- a/api/CcsSso.Core.JobScheduler/Jobs/OrganisationAutovalidationJob.cs
+++ b/api/CcsSso.Core.JobScheduler/Jobs/OrganisationAutovalidationJob.cs
@@ -152,7 +152,8 @@ namespace CcsSso.Core.JobScheduler
     public async Task<List<OrganisationDetail>> GetOrganisationsForAutoValidationAsync()
     {
       var organisations = await _dataContext.Organisation.Where(
-                          org => !org.IsDeleted && org.CreatedOnUtc >= TimeZoneInfo.ConvertTimeToUtc(startDate) && org.CreatedOnUtc <= TimeZoneInfo.ConvertTimeToUtc(endDate)
+                          org => org.RightToBuy == false
+                          && !org.IsDeleted && org.CreatedOnUtc >= TimeZoneInfo.ConvertTimeToUtc(startDate) && org.CreatedOnUtc <= TimeZoneInfo.ConvertTimeToUtc(endDate)
                           && !_dataContext.OrganisationAudit.Any(orgAudit => orgAudit.OrganisationId == org.Id))
                           .Select(o => new OrganisationDetail()
                           {


### PR DESCRIPTION
… (#1570)

* One time autovalidation job Fix1  - apply the auto validaiton rules to all the org admins Fix2  - apply role validation if the role's approval status is true. Role validation only applies to the secondary admins not the original(oldest admins)

* One time job will select organisation where right to buy is false.